### PR TITLE
Prevent duplicated function declaration.

### DIFF
--- a/src/WebWorkerThreads.cc
+++ b/src/WebWorkerThreads.cc
@@ -935,11 +935,9 @@ NAN_METHOD(Create) {
 
 #if NODE_MODULE_VERSION >= 0x000E
 void Init (Handle<Object> target, Handle<Value> module, void *) {
-#else
-#if NODE_MODULE_VERSION >= 0x000B
+#elif NODE_MODULE_VERSION >= 0x000B
 void Init (Handle<Object> target, Handle<Value> module) {
 #else
-#endif
 void Init (Handle<Object> target) {
 #endif
 


### PR DESCRIPTION
When attempting to use your module, I face the following compile error:

make: Entering directory '/home/chris/wym/wymconn/node/node_modules/webworker-threads/build'
  CXX(target) Release/obj.target/WebWorkerThreads/src/WebWorkerThreads.o
../src/WebWorkerThreads.cc: In function ‘void Init(v8::Handlev8::Object, v8::Handlev8::Value)’
../src/WebWorkerThreads.cc:943:35: error: a function-definition is not allowed here before ‘{’ token
 void Init (Handle<Object> target) {
                                   ^
../src/WebWorkerThreads.cc:975:8: error: expected unqualified-id before string constant
 NODE_MODULE(WebWorkerThreads, Init)
        ^
../src/WebWorkerThreads.cc:975:203: error: expected ‘}’ at end of input
 NODE_MODULE(WebWorkerThreads, Init)
                                                                                                                                                                                                           ^

This appears to be because the macros here are poorly-designed and, in my case, cause both lines:
 void Init (Handle<Object> target, Handle<Value> module) {
 void Init (Handle<Object> target) {

to be emitted.

Behold, a patch.
