### PR TITLE
Use ArrayBufferAllocator to support node 4.0/4.1

### DIFF
--- a/src/ArrayBufferAllocator.h
+++ b/src/ArrayBufferAllocator.h
@@ -1,0 +1,11 @@
+// from: https://developers.google.com/v8/get_started
+
+class ArrayBufferAllocator : public v8::ArrayBuffer::Allocator {
+ public:
+  virtual void* Allocate(size_t length) {
+    void* data = AllocateUninitialized(length);
+    return data == NULL ? data : memset(data, 0, length);
+  }
+  virtual void* AllocateUninitialized(size_t length) { return malloc(length); }
+  virtual void Free(void* data, size_t) { free(data); }
+};

--- a/src/WebWorkerThreads.cc
+++ b/src/WebWorkerThreads.cc
@@ -38,6 +38,8 @@ static int debug_allocs= 0;
 #include "bson.cc"
 #include "jslib.cc"
 
+#include "ArrayBufferAllocator.h"
+
 //using namespace node;
 using namespace v8;
 
@@ -228,7 +230,11 @@ static void aThread (void* arg) {
   pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, &dummy);
 
   typeThread* thread= (typeThread*) arg;
-  thread->isolate= Isolate::New();
+  // ref: https://developers.google.com/v8/get_started
+  ArrayBufferAllocator a;
+  v8::Isolate::CreateParams cp;
+  cp.array_buffer_allocator = &a;
+  thread->isolate= Isolate::New(cp);
   NanSetIsolateData(thread->isolate, thread);
   
   if (useLocker) {


### PR DESCRIPTION
For some reason, I had to add and use the ArrayBufferAllocator as described in https://developers.google.com/v8/get_started to avoid the crash in Node 4.x (4.0.0 or 4.1.1).

If this fix is accepted, there are a few more items I would like to work on:
- It looks like some work was done to port from pthreads to uv_thread, but `#define WWT_PTHREAD 1` is still there which forces the use of pthreads.
- There is a lot of old code which was commented out, and should simply be deleted.
- In a number of cases, the NAN wrapper always uses `v8::Isolate::GetCurrent()` while the Node/V8 API expects the Isolate pointer to be given explicitly. I think it would be safer to use the explicit Isolate pointer, if we can get the NAN project to support this.