### PR TITLE
Drop support for Node 0.8.x

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Compatibility
 
 * Support for Node 4.x (@brodybits)
+* Remove support for Node 0.8.x
 
 ## 0.5.7
 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
   },
   "gypfile": true,
   "engines": {
-    "node": ">= 0.8.0"
+    "node": ">= 0.10.16"
   }
 }

--- a/package.ls
+++ b/package.ls
@@ -41,4 +41,4 @@ dependencies:
 dev-dependencies:
   LiveScript: \1.3.x
 gypfile: true
-engines: { node: '>= 0.8.0' }
+engines: { node: '>= 0.10.16' }


### PR DESCRIPTION
The changes in PR #70 to completely drop the use of pthread API also broke support for Node 0.8.x, since it does not support `uv_cond_t`. Considering that Node 0.8.x is no longer supported anyway, I recommend that we simply drop support for that version.

In case of any objections please raise ASAP. I plan to include this change in `master` if I don't hear anything in the next 10-12 hours.