### PR TITLE
Fixes 2015.01.02 for review

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "webworker-threads",
   "version": "0.6.0",
-  "main": "build/Release/WebWorkerThreads.node",
+  "main": "index.js",
   "description": "Lightweight Web Worker API implementation with native threads",
   "keywords": [
     "threads",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webworker-threads",
-  "version": "0.6.0",
+  "version": "0.6.1-dev",
   "main": "index.js",
   "description": "Lightweight Web Worker API implementation with native threads",
   "keywords": [

--- a/package.ls
+++ b/package.ls
@@ -1,7 +1,7 @@
 #!/usr/bin/env lsc -cj
 name: \webworker-threads
 version: \0.6.0
-main: \build/Release/WebWorkerThreads.node
+main: \index.js
 description: 'Lightweight Web Worker API implementation with native threads'
 keywords: [ 'threads' 'web worker' 'a gogo' ]
 author:

--- a/package.ls
+++ b/package.ls
@@ -1,6 +1,6 @@
 #!/usr/bin/env lsc -cj
 name: \webworker-threads
-version: \0.6.0
+version: \0.6.1-dev
 main: \index.js
 description: 'Lightweight Web Worker API implementation with native threads'
 keywords: [ 'threads' 'web worker' 'a gogo' ]


### PR DESCRIPTION
- Fix crash on Node 4.x in the case of `pool.any.eval('undefined_function()')` (#73) or `pool.any.eval('invalid code')` (also whitespace cleaned up by my editor)
- Fix main: \index.js in package.{ls,json} due to PR #70
- Mark 0.6.1-dev

I will push these to master if there are no objections.