### PR TITLE
Fix npm install failure on windows due to missing 'alloca'

### DIFF
--- a/src/bson.cc
+++ b/src/bson.cc
@@ -28,6 +28,11 @@
 #include <limits>
 #include <vector>
 
+#ifdef _WIN32 || _WIN64
+    // For alloca().
+    #include <malloc.h>
+#endif
+
 #if defined(__sun) || defined(_AIX)
 	#include <alloca.h>
 #endif


### PR DESCRIPTION
This PR addresses the following npm install error on windows:

```
webworker-threads\src\bson.cc(70): error C3861:
 'alloca': identifier not found
```