### PR TITLE
Resolve compiler warnings on Node v7

### DIFF
--- a/src/WebWorkerThreads.cc
+++ b/src/WebWorkerThreads.cc
@@ -25,7 +25,7 @@ using namespace v8;
 
 static Nan::Persistent<String> id_symbol;
 static Nan::Persistent<ObjectTemplate> threadTemplate;
-static bool useLocker;
+static bool useLocker; /* True if the initial V8 instance had a Locker. We'll follow suit. */
 
 static typeQueue* freeJobsQueue= NULL;
 static typeQueue* freeThreadsQueue= NULL;
@@ -214,11 +214,7 @@ static void aThread (void* arg) {
   NanSetIsolateData(thread->isolate, thread);
 
   if (useLocker) {
-	#if (NODE_MODULE_VERSION > 0x000B)
 		v8::Locker myLocker(thread->isolate);
-	#else
-		v8::Locker myLocker(thread->isolate);
-	#endif
     // I think it's not ok to create a isolate scope here,
     // because it will call Isolate::Exit automatically.
     //v8::Isolate::Scope isolate_scope(thread->isolate);
@@ -261,28 +257,28 @@ static void eventLoop (typeThread* thread) {
 
     Local<Object> fs_obj = Nan::New<Object>();
     JSObjFn(fs_obj, "readFileSync", readFileSync_);
-    global->ForceSet(Nan::New<String>("native_fs_").ToLocalChecked(), fs_obj, attribute_ro_dd);
+    Nan::ForceSet(global, Nan::New<String>("native_fs_").ToLocalChecked(), fs_obj, attribute_ro_dd);
 
     Local<Object> console_obj = Nan::New<Object>();
     JSObjFn(console_obj, "log", console_log);
     JSObjFn(console_obj, "error", console_error);
-    global->ForceSet(Nan::New<String>("console").ToLocalChecked(), console_obj, attribute_ro_dd);
+    Nan::ForceSet(global, Nan::New<String>("console").ToLocalChecked(), console_obj, attribute_ro_dd);
 
-    global->ForceSet(Nan::New<String>("self").ToLocalChecked(), global);
-    global->ForceSet(Nan::New<String>("global").ToLocalChecked(), global);
+    Nan::ForceSet(global, Nan::New<String>("self").ToLocalChecked(), global, v8::None);
+    Nan::ForceSet(global, Nan::New<String>("global").ToLocalChecked(), global, v8::None);
 
-    global->ForceSet(Nan::New<String>("puts").ToLocalChecked(), Nan::New<FunctionTemplate>(Puts)->GetFunction());
-    global->ForceSet(Nan::New<String>("print").ToLocalChecked(), Nan::New<FunctionTemplate>(Print)->GetFunction());
+    Nan::ForceSet(global, Nan::New<String>("puts").ToLocalChecked(), Nan::New<FunctionTemplate>(Puts)->GetFunction(), v8::None);
+    Nan::ForceSet(global, Nan::New<String>("print").ToLocalChecked(), Nan::New<FunctionTemplate>(Print)->GetFunction(), v8::None);
 
-    global->ForceSet(Nan::New<String>("postMessage").ToLocalChecked(), Nan::New<FunctionTemplate>(postMessage)->GetFunction());
-    global->ForceSet(Nan::New<String>("__postError").ToLocalChecked(), Nan::New<FunctionTemplate>(postError)->GetFunction());
+    Nan::ForceSet(global, Nan::New<String>("postMessage").ToLocalChecked(), Nan::New<FunctionTemplate>(postMessage)->GetFunction(), v8::None);
+    Nan::ForceSet(global, Nan::New<String>("__postError").ToLocalChecked(), Nan::New<FunctionTemplate>(postError)->GetFunction(), v8::None);
 
     Local<Object> threadObject= Nan::New<Object>();
-    global->ForceSet(Nan::New<String>("thread").ToLocalChecked(), threadObject);
+    Nan::ForceSet(global, Nan::New<String>("thread").ToLocalChecked(), threadObject, v8::None);
 
     threadObject->Set(Nan::New<String>("id").ToLocalChecked(), Nan::New<Number>(thread->id));
     threadObject->Set(Nan::New<String>("emit").ToLocalChecked(), Nan::New<FunctionTemplate>(threadEmit)->GetFunction());
-    Local<Object> dispatchEvents= Script::Compile(Nan::New<String>(kEvents_js).ToLocalChecked())->Run()->ToObject()->CallAsFunction(threadObject, 0, NULL)->ToObject();
+    Local<Object> dispatchEvents= Nan::CallAsFunction(Script::Compile(Nan::New<String>(kEvents_js).ToLocalChecked())->Run()->ToObject(), threadObject, 0, NULL).ToLocalChecked()->ToObject();
     Local<Object> dispatchNextTicks= Script::Compile(Nan::New<String>(kThread_nextTick_js).ToLocalChecked())->Run()->ToObject();
 
     Array* _ntq = Array::Cast(*threadObject->Get(Nan::New<String>("_ntq").ToLocalChecked()));
@@ -298,7 +294,7 @@ static void eventLoop (typeThread* thread) {
 
       {
         Nan::HandleScope scope;
-        TryCatch onError;
+        Nan::TryCatch onError;
         String::Utf8Value* str;
         Local<String> source;
         Local<Value> resultado;
@@ -368,7 +364,7 @@ static void eventLoop (typeThread* thread) {
 
             free(job->typeEvent.argumentos);
             queue_push(qitem, freeJobsQueue);
-            dispatchEvents->CallAsFunction(global, 2, info);
+            Nan::CallAsFunction(dispatchEvents, global, 2, info);
           }
           else if (job->jobType == kJobTypeEventSerialized) {
             Local<Value> info[2];
@@ -392,7 +388,7 @@ static void eventLoop (typeThread* thread) {
         }
 
             queue_push(qitem, freeJobsQueue);
-            dispatchEvents->CallAsFunction(global, 2, info);
+            Nan::CallAsFunction(dispatchEvents, global, 2, info);
           }
         }
 
@@ -403,7 +399,7 @@ static void eventLoop (typeThread* thread) {
             Nan::IdleNotification(1000);
           }
 
-          resultado= dispatchNextTicks->CallAsFunction(global, 0, NULL);
+          resultado= Nan::CallAsFunction(dispatchNextTicks, global, 0, NULL).ToLocalChecked();
           if (onError.HasCaught()) {
             nextTickQueueLength= 1;
             onError.Reset();
@@ -477,7 +473,7 @@ static void Callback (uv_async_t *watcher, int revents) {
   typeQueueItem* qitem;
   String::Utf8Value* str;
 
-  TryCatch onError;
+  Nan::TryCatch onError;
   while ((qitem= queue_pull(&thread->outQueue))) {
     job= (typeJob*) qitem->asPtr;
 
@@ -493,7 +489,7 @@ static void Callback (uv_async_t *watcher, int revents) {
           argv[0]= null;
           argv[1]= Nan::New<String>(**str, (*str).length()).ToLocalChecked();
         }
-        Nan::New(job->cb)->CallAsFunction(Nan::New(thread->JSObject), 2, argv);
+        Nan::CallAsFunction(Nan::New(job->cb), Nan::New(thread->JSObject), 2, argv);
         job->cb.Reset();
         job->typeEval.tiene_callBack= 0;
 
@@ -507,14 +503,7 @@ static void Callback (uv_async_t *watcher, int revents) {
         if (thread->outQueue.first) {
           uv_async_send(&thread->async_watcher); // wake up callback again
         }
-#if NODE_MODULE_VERSION >= 0x000E
-        if (useLocker) {
-          v8::Locker myLocker(thread->isolate);
-        }
-        node::FatalException(thread->isolate, onError);
-#else
-        node::FatalException(onError);
-#endif
+        Nan::FatalException(onError);
         return;
       }
     }
@@ -541,7 +530,7 @@ static void Callback (uv_async_t *watcher, int revents) {
 
       free(job->typeEvent.argumentos);
       queue_push(qitem, freeJobsQueue);
-      Nan::New(thread->dispatchEvents)->CallAsFunction(Nan::New(thread->JSObject), 2, info);
+      Nan::CallAsFunction(Nan::New(thread->dispatchEvents), Nan::New(thread->JSObject), 2, info);
     }
     else if (job->jobType == kJobTypeEventSerialized) {
       Local<Value> info[2];
@@ -566,7 +555,7 @@ static void Callback (uv_async_t *watcher, int revents) {
         }
 
       queue_push(qitem, freeJobsQueue);
-      Nan::New(thread->dispatchEvents)->CallAsFunction(Nan::New(thread->JSObject), 2, info);
+      Nan::CallAsFunction(Nan::New(thread->dispatchEvents), Nan::New(thread->JSObject), 2, info);
     }
   }
 }
@@ -878,7 +867,7 @@ NAN_METHOD(Create) {
     Nan::SetInternalFieldPointer(local_JSObject, 0, thread);
     thread->JSObject.Reset(local_JSObject);
 
-    Local<Value> dispatchEvents= Script::Compile(Nan::New<String>(kEvents_js).ToLocalChecked())->Run()->ToObject()->CallAsFunction(local_JSObject, 0, NULL);
+    Local<Value> dispatchEvents= Nan::CallAsFunction(Script::Compile(Nan::New<String>(kEvents_js).ToLocalChecked())->Run()->ToObject(), local_JSObject, 0, NULL).ToLocalChecked();
 	Local<Object> local_dispatchEvents = dispatchEvents->ToObject();
     thread->dispatchEvents.Reset(local_dispatchEvents);
 
@@ -919,12 +908,14 @@ void Init (Handle<Object> target) {
   useLocker= v8::Locker::IsActive();
 
   target->Set(Nan::New<String>("create").ToLocalChecked(), Nan::New<FunctionTemplate>(Create)->GetFunction());
-  target->Set(Nan::New<String>("createPool").ToLocalChecked(), Script::Compile(Nan::New<String>(kCreatePool_js).ToLocalChecked())->Run()->ToObject());
-  target->Set(Nan::New<String>("Worker").ToLocalChecked(), Script::Compile(Nan::New<String>(kWorker_js).ToLocalChecked())->Run()->ToObject()->CallAsFunction(target, 0, NULL)->ToObject());
+  target->Set(Nan::New<String>("createPool").ToLocalChecked(),
+    Script::Compile(Nan::New<String>(kCreatePool_js).ToLocalChecked())->Run()->ToObject());
+  target->Set(Nan::New<String>("Worker").ToLocalChecked(),
+    Nan::CallAsFunction(Script::Compile(Nan::New<String>(kWorker_js).ToLocalChecked())->Run()->ToObject(), target, 0, NULL).ToLocalChecked()->ToObject());
 
   Local<String> local_id_symbol = Nan::New<String>("id").ToLocalChecked();
 
-  Local<ObjectTemplate> local_threadTemplate = ObjectTemplate::New();
+  Local<ObjectTemplate> local_threadTemplate = Nan::New<ObjectTemplate>();
   local_threadTemplate->SetInternalFieldCount(1);
   local_threadTemplate->Set(local_id_symbol, Nan::New<Integer>(0));
   id_symbol.Reset(local_id_symbol);

--- a/src/bson.cc
+++ b/src/bson.cc
@@ -431,7 +431,7 @@ Local<Value> BSONDeserializer::DeserializeDocumentInternal(bool promoteLongs)
 		if(name->IsNull()) ThrowAllocatedStringException(64, "Bad BSON Document: illegal CString");
 		// name->Is
         const Local<Value>& value = DeserializeValue(type, promoteLongs);
-		returnObject->ForceSet(name, value);
+		Nan::ForceSet(returnObject, name, value, v8::None);
 	}
 	if(p != pEnd) ThrowAllocatedStringException(64, "Bad BSON Document: Serialize consumed unexpected number of bytes");
 
@@ -440,7 +440,7 @@ Local<Value> BSONDeserializer::DeserializeDocumentInternal(bool promoteLongs)
     if(returnObject->Has(Nan::New(bson->_dbRefIdRefString)))
 	{
         Local<Value> argv[] = { returnObject->Get(Nan::New(bson->_dbRefRefString)), returnObject->Get(Nan::New(bson->_dbRefIdRefString)), returnObject->Get(Nan::New(bson->_dbRefDbRefString)) };
-        return Nan::New(bson->dbrefConstructor)->NewInstance(3, argv);
+        return Nan::NewInstance(Nan::New(bson->dbrefConstructor), 3, argv).ToLocalChecked();
 	}
 	else
 	{
@@ -497,7 +497,7 @@ Local<Value> BSONDeserializer::DeserializeValue(BsonType type, bool promoteLongs
 			int32_t lowBits = ReadInt32();
 			int32_t highBits = ReadInt32();
             Local<Value> argv[] = { Nan::New<Int32>(lowBits), Nan::New<Int32>(highBits) };
-            return Nan::New(bson->timestampConstructor)->NewInstance(2, argv);
+            return Nan::NewInstance(Nan::New(bson->timestampConstructor), 2, argv).ToLocalChecked();
 		}
 
 	case BSON_TYPE_BOOLEAN:
@@ -516,7 +516,7 @@ Local<Value> BSONDeserializer::DeserializeValue(BsonType type, bool promoteLongs
 			const Local<Value>& code = ReadString();
             const Local<Value>& scope = Nan::New<Object>();
 			Local<Value> argv[] = { code, scope };
-            return Nan::New(bson->codeConstructor)->NewInstance(2, argv);
+            return Nan::NewInstance(Nan::New(bson->codeConstructor), 2, argv).ToLocalChecked();
 		}
 
 	case BSON_TYPE_CODE_W_SCOPE:
@@ -525,13 +525,13 @@ Local<Value> BSONDeserializer::DeserializeValue(BsonType type, bool promoteLongs
 			const Local<Value>& code = ReadString();
             const Local<Value>& scope = DeserializeDocument(promoteLongs);
 			Local<Value> argv[] = { code, scope->ToObject() };
-            return Nan::New(bson->codeConstructor)->NewInstance(2, argv);
+            return Nan::NewInstance(Nan::New(bson->codeConstructor), 2, argv).ToLocalChecked();
 		}
 
 	case BSON_TYPE_OID:
 		{
 			Local<Value> argv[] = { ReadObjectId() };
-            return Nan::New(bson->objectIDConstructor)->NewInstance(1, argv);
+            return Nan::NewInstance(Nan::New(bson->objectIDConstructor), 1, argv).ToLocalChecked();
 		}
 
 	case BSON_TYPE_BINARY:
@@ -546,7 +546,7 @@ Local<Value> BSONDeserializer::DeserializeValue(BsonType type, bool promoteLongs
 			p += length;
 
             Local<Value> argv[] = { buffer, Nan::New<Uint32>(subType) };
-            return Nan::New(bson->binaryConstructor)->NewInstance(2, argv);
+            return Nan::NewInstance(Nan::New(bson->binaryConstructor), 2, argv).ToLocalChecked();
 		}
 
 	case BSON_TYPE_LONG:
@@ -569,7 +569,7 @@ Local<Value> BSONDeserializer::DeserializeValue(BsonType type, bool promoteLongs
 
 			// Decode the Long value
             Local<Value> argv[] = { Nan::New<Int32>(lowBits), Nan::New<Int32>(highBits) };
-            return Nan::New(bson->longConstructor)->NewInstance(2, argv);
+            return Nan::NewInstance(Nan::New(bson->longConstructor), 2, argv).ToLocalChecked();
 		}
 
 	case BSON_TYPE_DATE:
@@ -585,14 +585,14 @@ Local<Value> BSONDeserializer::DeserializeValue(BsonType type, bool promoteLongs
 		{
 			const Local<String>& string = ReadString();
 			Local<Value> argv[] = { string };
-            return Nan::New(bson->symbolConstructor)->NewInstance(1, argv);
+            return Nan::NewInstance(Nan::New(bson->symbolConstructor), 1, argv).ToLocalChecked();
 		}
 
 	case BSON_TYPE_MIN_KEY:
-        return Nan::New(bson->minKeyConstructor)->NewInstance();
+        return Nan::NewInstance(Nan::New(bson->minKeyConstructor)).ToLocalChecked();
 
 	case BSON_TYPE_MAX_KEY:
-        return Nan::New(bson->maxKeyConstructor)->NewInstance();
+        return Nan::NewInstance(Nan::New(bson->maxKeyConstructor)).ToLocalChecked();
 
 	default:
 		ThrowAllocatedStringException(64, "Unhandled BSON Type: %d", type);
@@ -655,7 +655,7 @@ void BSON::Initialize(v8::Local<v8::Object> target)
 
     constructor_template.Reset(t);
 
-    target->ForceSet(Nan::New<String>("BSON").ToLocalChecked(), t->GetFunction());
+    Nan::ForceSet(target, Nan::New<String>("BSON").ToLocalChecked(), t->GetFunction(), v8::None);
 }
 
 // Create a new instance of BSON and passing it the existing context

--- a/src/jslib.cc
+++ b/src/jslib.cc
@@ -21,10 +21,12 @@
 
 static const PropertyAttribute attribute_ro_dd = (PropertyAttribute)(ReadOnly | DontDelete);
 static const PropertyAttribute attribute_ro_de_dd = (PropertyAttribute)(ReadOnly | DontEnum | DontDelete);
-#define JSObjFn(obj, name, fnname) \
-    obj->ForceSet(Nan::New<String>(name).ToLocalChecked(), Nan::New<FunctionTemplate>(fnname)->GetFunction(), attribute_ro_dd);
 
-static void ReportException(TryCatch* try_catch) {
+// 'obj.name = fnname' with PropertyAttribute attribute_ro_dd.
+#define JSObjFn(obj, name, fnname) \
+    Nan::ForceSet(obj, Nan::New<String>(name).ToLocalChecked(), Nan::New<FunctionTemplate>(fnname)->GetFunction(), attribute_ro_dd);
+
+static void ReportException(Nan::TryCatch* try_catch) {
     Nan::HandleScope scope;
 
 	String::Utf8Value exception(try_catch->Exception());
@@ -55,13 +57,13 @@ static void ReportException(TryCatch* try_catch) {
 		for (int i = 0; i < start; i++) {
 			putchar(' ');
 		}
-		int end = message->GetEndColumn();
+		int end = Nan::GetEndColumn(message).FromJust();
 		for (int i = start; i < end; i++) {
 			putchar('^');
 		}
 		putchar('\n');
 
-		String::Utf8Value stack_trace(try_catch->StackTrace());
+		String::Utf8Value stack_trace(try_catch->StackTrace().ToLocalChecked());
 		if (stack_trace.length() > 0) {
 			printf("%s\n", *stack_trace);
 		}
@@ -156,7 +158,7 @@ static inline void console_common_1(const Local<Value> &v, FILE* fd, const int d
 NAN_METHOD(console_log) {
     Nan::HandleScope scope;
 	
-	TryCatch trycatch;
+	Nan::TryCatch trycatch;
 	
     for (int i=0, n=info.Length(); i<n; ++i) {
         console_common_1(info[i], stdout, 0);
@@ -172,7 +174,7 @@ NAN_METHOD(console_log) {
 NAN_METHOD(console_error) {
     Nan::HandleScope scope;
 	
-	TryCatch trycatch;
+	Nan::TryCatch trycatch;
 	
     for (int i=0, n=info.Length(); i<n; ++i) {
         console_common_1(info[i], stderr, 0);


### PR DESCRIPTION
Whatever V8 is behind Node v7.4.0 deprecated some V8 methods, so switch to Nan where needed.

This resolves #135.

All tests pass just as well as they did before.

Bonus: In a few places I eliminated redundancy in the use of v8::Locker. I can break this out into a separate PR if you want.