### PR TITLE
README: Add link to developer guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,10 @@ Same as `console.log`, except it prints to stderr.
 ##### puts(arg1 [, arg2 ...])
 `puts(arg1 [, arg2 ...])` converts .toString()s and prints its arguments to stdout.
 
+## Developer guide
+
+See the [developer guide](https://github.com/audreyt/node-webworker-threads/wiki) if you want to contribute.
+
 -----------
 WIP WIP WIP
 -----------


### PR DESCRIPTION
I put some content into the node-webworker-threads GitHub wiki. We can move it to a docs/ subdir if preferred, but I wanted to jot down the notes I've been making as I've been studying this module.