### PR TITLE
Test22 - don't run forever

### DIFF
--- a/test/test22_create_destroy_loop.js
+++ b/test/test22_create_destroy_loop.js
@@ -2,24 +2,36 @@
 
 var T= require('../');
 
+var MAX_THREADS = 1000;
+var THREADS_PER_ITER = 5;
 
-var i= 0;
-var k= 5;
-(function again () {
-  var j= k;
-  while (j--) {
-    T.create().destroy();
-  }
-  i+= k;
-  process.nextTick(again);
-})();
+var threadCount = 0; /* # of threads created so far. */
 
-
+/* Indicate create/destroy rate. */
+var reportFreqInMs = 5e2;
 var t= Date.now();
 function display () {
   var e= Date.now()- t;
-  var tps= (i*1e3/e).toFixed(1);
-  process.stdout.write('\nt (ms) -> '+ e+ ', i -> '+ i+ ', created/destroyed-per-second -> '+ tps);
+  var tps= (threadCount*1e3/e).toFixed(1);
+  process.stdout.write('\nt (ms) -> '+ e+ ', threadCount -> '+ threadCount + ', created/destroyed-per-second -> '+ tps + '\n');
 }
 
-setInterval(display, 1e3);
+var displayInterval = setInterval(display, reportFreqInMs);
+
+/* Create and destroy MAX_THREADS threads. */
+
+(function again () {
+  var i;
+  for (i = 0; i < THREADS_PER_ITER; i++) {
+    T.create().destroy();
+  }
+  threadCount += THREADS_PER_ITER;
+
+  if (threadCount < MAX_THREADS) {
+    setTimeout(again, 0);
+  }
+  else {
+    clearInterval(displayInterval);
+    display();
+  }
+})();


### PR DESCRIPTION
1. Don't run forever.

Problem: It was creating an infinite number of threads.
Solution: Create 1000 threads, enough to prove the point.

2. Actually print ongoing updates.

Problem: It was using process.nextTick to queue the next set of threads.
         On recent versions of Node this means display() will never get to run.

Solution: Switch to setTimeout(again, 0).

This commit is toward #144 .