### PR TITLE
issue #144: npm test builds and runs all suites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 node_modules
 npm-debug.log
 deps/minifier/bin/minify
+run-all-tests-output.log

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   },
   "scripts": {
     "js": "env PATH=./node_modules/.bin:\"$PATH\" lsc -cj package.ls;\ngcc deps/minifier/src/minify.c -o deps/minifier/bin/minify;\nenv PATH=./node_modules/.bin:\"$PATH\" lsc -cbp src/worker.ls                    > src/worker.js;\n./deps/minifier/bin/minify kWorker_js            < src/worker.js          > src/worker.js.c;\nenv PATH=./node_modules/.bin:\"$PATH\" lsc -cbp src/events.ls                    > src/events.js;\n./deps/minifier/bin/minify kEvents_js            < src/events.js          > src/events.js.c;\nenv PATH=./node_modules/.bin:\"$PATH\" lsc -cbp src/createPool.ls                > src/createPool.js;\n./deps/minifier/bin/minify kCreatePool_js        < src/createPool.js      > src/createPool.js.c;\nenv PATH=./node_modules/.bin:\"$PATH\" lsc -cbp src/thread_nextTick.ls           > src/thread_nextTick.js;\n./deps/minifier/bin/minify kThread_nextTick_js 1 < src/thread_nextTick.js > src/thread_nextTick.js.c;\nenv PATH=./node_modules/.bin:\"$PATH\" lsc -cbp src/load.ls                      > src/load.js;\n./deps/minifier/bin/minify kLoad_js 1 1          < src/load.js            > src/load.js.c;",
-    "test": "node test-package.js"
+    "pretest": "npm run js",
+    "test": "./run-all-tests.sh"
   },
   "dependencies": {
     "bindings": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -35,12 +35,12 @@
   },
   "scripts": {
     "js": "env PATH=./node_modules/.bin:\"$PATH\" lsc -cj package.ls;\ngcc deps/minifier/src/minify.c -o deps/minifier/bin/minify;\nenv PATH=./node_modules/.bin:\"$PATH\" lsc -cbp src/worker.ls                    > src/worker.js;\n./deps/minifier/bin/minify kWorker_js            < src/worker.js          > src/worker.js.c;\nenv PATH=./node_modules/.bin:\"$PATH\" lsc -cbp src/events.ls                    > src/events.js;\n./deps/minifier/bin/minify kEvents_js            < src/events.js          > src/events.js.c;\nenv PATH=./node_modules/.bin:\"$PATH\" lsc -cbp src/createPool.ls                > src/createPool.js;\n./deps/minifier/bin/minify kCreatePool_js        < src/createPool.js      > src/createPool.js.c;\nenv PATH=./node_modules/.bin:\"$PATH\" lsc -cbp src/thread_nextTick.ls           > src/thread_nextTick.js;\n./deps/minifier/bin/minify kThread_nextTick_js 1 < src/thread_nextTick.js > src/thread_nextTick.js.c;\nenv PATH=./node_modules/.bin:\"$PATH\" lsc -cbp src/load.ls                      > src/load.js;\n./deps/minifier/bin/minify kLoad_js 1 1          < src/load.js            > src/load.js.c;",
-    "pretest": "npm run js",
+    "pretest": "npm run js && node-gyp rebuild",
     "test": "./run-all-tests.sh"
   },
   "dependencies": {
-    "bindings": "^1.2.1",
-    "nan": "^2.4.0"
+    "bindings": "^1.3.0",
+    "nan": "^2.8.0"
   },
   "devDependencies": {
     "livescript": "^1.5.0",

--- a/package.ls
+++ b/package.ls
@@ -36,7 +36,8 @@ scripts:
     env PATH=./node_modules/.bin:"$PATH" lsc -cbp src/load.ls                      > src/load.js;
     ./deps/minifier/bin/minify kLoad_js 1 1          < src/load.js            > src/load.js.c;
   """
-  test: 'node test-package.js'
+  pretest: 'npm run js'
+  test: './run-all-tests.sh'
 dependencies:
   bindings: \^1.2.1
   nan: \^2.4.0

--- a/package.ls
+++ b/package.ls
@@ -36,11 +36,11 @@ scripts:
     env PATH=./node_modules/.bin:"$PATH" lsc -cbp src/load.ls                      > src/load.js;
     ./deps/minifier/bin/minify kLoad_js 1 1          < src/load.js            > src/load.js.c;
   """
-  pretest: 'npm run js'
+  pretest: 'npm run js && node-gyp rebuild'
   test: './run-all-tests.sh'
 dependencies:
-  bindings: \^1.2.1
-  nan: \^2.4.0
+  bindings: \^1.3.0
+  nan: \^2.8.0
 dev-dependencies:
   livescript: \^1.5.0
   tap: \^5.7.1

--- a/run-all-tests.sh
+++ b/run-all-tests.sh
@@ -2,6 +2,8 @@
 
 OUTPUT="./run-all-tests-output.log"
 
+exit_code=0
+
 node ./test-package.js > ${OUTPUT}
 
 _term() {
@@ -21,5 +23,8 @@ for filename in ./test/*.js; do
         echo ${filename} "passed!"
     else
         echo ${filename} "failed!"
+        exit_code=1
     fi
 done
+
+exit ${exit_code}

--- a/run-all-tests.sh
+++ b/run-all-tests.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+OUTPUT="./run-all-tests-output.log"
+
+node ./test-package.js > ${OUTPUT}
+
+for filename in ./test/*.js; do
+    echo ${filename}
+    node "${filename}" >> ${OUTPUT}
+done
+

--- a/run-all-tests.sh
+++ b/run-all-tests.sh
@@ -1,13 +1,25 @@
 #!/usr/bin/env bash
 
-set -e
-
 OUTPUT="./run-all-tests-output.log"
 
 node ./test-package.js > ${OUTPUT}
 
-for filename in ./test/*.js; do
-    echo ${filename}
-    node "${filename}" >> ${OUTPUT}
-done
+_term() {
+  echo "Caught SIGTERM signal!"
+  kill -TERM "$child" 2>/dev/null
+}
 
+trap _term SIGTERM
+
+for filename in ./test/*.js; do
+    timeout 5s node "${filename}" >> ${OUTPUT} &
+
+    child=$!
+    wait "${child}"
+
+    if [ $? = 0 ]; then
+        echo ${filename} "passed!"
+    else
+        echo ${filename} "failed!"
+    fi
+done


### PR DESCRIPTION
Change npm test command to build the module and then run a simple bash script that runs each test file in the /test directory

* Outputs success or fail line for each script
* Exits with code 1 if any suites fail
* Timeouts out commands after 5 seconds
* Relatively gracefully handles sigterm
* Pipes test output to file

Note that on node v8.9.4 many suites are failing. Hoping to get time to try and understand this further, but thought this might aid others that may be on similar quests.