### PR TITLE
Fix Windows load delay validation for Node v10.x

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -16,7 +16,7 @@
       "include_dirs": [
         "<!(node -e \"require('nan')\")"
       ],
-      "win_delay_load_hook": "<!(node -e \"var v = process.version.substring(1,2); console.log(v > 0 && v < 4);\")",
+      "win_delay_load_hook": "<!(node -e \"var v = process.version.substring(1).split('.')[0]; console.log(v > 0 && v < 4);\")",
       "conditions": [
         [
           "OS==\"mac\"",


### PR DESCRIPTION
- Fixes Windows load delay validation when using greater than node 10.x
- It would previously only validate the first digit
- Related to issue https://github.com/audreyt/node-webworker-threads/issues/179

##### TEST CASE
- Requirements
  - Windows, Node v10.x
```
npm install
```

- Should build `WebWorkerThreads.node` successfully, without link exception:
```
LINK : fatal error LNK1194: cannot delay-load 'node.exe' due to import of data symbol '"__declspec(dllimport) const v 8::ArrayBuffer::Allocator::`vftable'" (__imp_??_7Allocator@ArrayBuffer@v8@@6B@)'; link without /DELAYLOAD:node.exe
```